### PR TITLE
Make README instructions useful

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 .idea
 .eggs
 venv
+*.deb

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Building the debian package
 
 ```
 # Install build tools:
-sudo apt install build-essential devscripts debhelper dh-systemd
-
-# Install dependencies
-sudo apt install libusb-1.0-0-dev python3-cffi
+sudo apt install build-essential devscripts debhelper dh-systemd equivs
 
 # cd to the root of this project
 cd path/to/robotd
+
+# Install dependencies
+sudo mk-build-deps -ir
 
 # Build the package:
 debuild -uc -us

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Tour of the source
 Building the Debian package
 ---------------------------
 
-Install through apt:
+``` bash
+# Install build tools:
+sudo apt install build-essential devscripts debhelper dh-systemd
 
-* `build-essential`
-* `devscripts`
-* `debhelper`
-* `dh-systemd`
+# cd to the root of this project
+cd path/to/robotd
 
-And then run, from the root of the project:
-
-* `debuild -uc -us`
+# Build the package:
+debuild -uc -us
+```

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ once done you can `pip install -e .` as usual.
 Building the debian package
 ---------------------------
 
-Ensure
-
 ```
 # Install build tools:
 sudo apt install build-essential devscripts debhelper dh-systemd

--- a/README.md
+++ b/README.md
@@ -17,12 +17,31 @@ Tour of the source
 * `robotd/devices_base.py` contains some common code for `devices.py`.
 * `robotd.service` is the systemd service which runs the thing in production.
 
-Building the Debian package
----------------------------
+Getting started
+---------------
+
+Since `robotd` vendors in April Tags for its vision support, which depends on
+`libusb`, you'll need to install the development package for `libusb` in order
+to build the python package:
 
 ``` bash
+sudo apt install libusb-1.0-0-dev
+```
+
+Without this you'll likely see errors building the apriltags source. However,
+once done you can `pip install -e .` as usual.
+
+Building the debian package
+---------------------------
+
+Ensure
+
+```
 # Install build tools:
 sudo apt install build-essential devscripts debhelper dh-systemd
+
+# Install dependencies
+sudo apt install libusb-1.0-0-dev python3-cffi
 
 # cd to the root of this project
 cd path/to/robotd


### PR DESCRIPTION
This now includes the instructions for building the python package on Ubuntu, which seems fairly representative of a Debian machine.

Note: the `debuild` doesn't actually work for me yet as I've not worked out how to get `python3-pygame` (which seems to be needed) installed; it's not in the repos for Ubuntu 16.04.