### PR TITLE
Allow dependency injection to camera for testing

### DIFF
--- a/robotd/devices.py
+++ b/robotd/devices.py
@@ -181,17 +181,22 @@ class Camera(Board):
     DISTANCE_MODEL = 'c270'
     IMAGE_SIZE = (1280, 720)
 
+    def __init__(self, node, camera=None):
+        super().__init__(node)
+        self.camera = camera
+
     @classmethod
     def name(cls, node):
         # Get device name
         return Path(node['DEVNAME']).stem
 
     def start(self):
-        self.camera = VisionCamera(
-            int(self.node['MINOR']),
-            self.IMAGE_SIZE,
-            self.DISTANCE_MODEL,
-        )
+        if not self.camera:
+            self.camera = VisionCamera(
+                int(self.node['MINOR']),
+                self.IMAGE_SIZE,
+                self.DISTANCE_MODEL,
+            )
         self.vision = Vision(self.camera)
 
         self._status = {'markers': []}


### PR DESCRIPTION
unit tests initialise a real board with a FileCamera for testing with known images, this re-adds dependency injection that was in the previous write of the Camera class to allow these tests to pass