### PR TITLE
Explicitly decode byte string

### DIFF
--- a/robotd/master.py
+++ b/robotd/master.py
@@ -37,7 +37,7 @@ class Connection:
         line = self.data.split(b'\n', 1)[0]
         self.data = self.data[len(line) + 1:]
 
-        return json.loads(line)
+        return json.loads(line.decode('utf-8'))
 
 
 class BoardRunner(multiprocessing.Process):


### PR DESCRIPTION
I was testing on Python 3.6 which accepts bytes for json.load.