### PR TITLE
MasterProcess: ensure root directory exists before attempting to traverse it

### DIFF
--- a/robotd/master.py
+++ b/robotd/master.py
@@ -198,6 +198,7 @@ class MasterProcess(object):
         self.context = pyudev.Context()
         self.root_dir = Path(root_dir)
 
+        self.root_dir.mkdir(mode=0o755, parents=True, exist_ok=True)
         self.clear_socket_files()
 
         self.runners_lock = threading.Lock()


### PR DESCRIPTION
This change stops robotd from crashing with a FileNotFoundError when it calls `self.root_dir.iterdir()` in `clear_socket_files`, in the event that `self.root_dir` does not already exist.

Fixes #23.