### PR TITLE
 Convert the camera to being capture-on-demand

### DIFF
--- a/robotd/devices.py
+++ b/robotd/devices.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import random
 import struct
 import subprocess
-from threading import Lock, Thread, Event
 import time
 
 from sb_vision import Camera as VisionCamera, Vision, Token
@@ -247,9 +246,6 @@ class Camera(Board):
             'markers': [],
         }
 
-        self.vision_thread = Thread(target=self._vision_thread)
-        self.vision_thread.start()
-
     def _update_status(self, markers):
         self._status = {
             'snapshot_timestamp': time.time(),
@@ -263,18 +259,18 @@ class Camera(Board):
         d['cartesian'] = marker.cartesian.tolist()
         return d
 
-    def _vision_thread(self):
-        while True:
-            markers = [self._serialise_marker(x) for x in self.vision.snapshot()]
-            self._update_status(markers)
-            self.broadcast(self._status)
-
     def status(self):
         return self._status
 
     def command(self, cmd):
         """Run user-provided command."""
-        pass
+        if cmd.get('see', False):
+            self._update_status(markers=[
+                self._serialise_marker(x)
+                for x in self.vision.snapshot()
+            ])
+            # rely on the status being sent back to the requesting connection
+            # by the ``BoardRunner``.
 
 
 class ServoAssembly(Board):


### PR DESCRIPTION
This means that users need to wait for the image to be processed but gives them much more control over how old the image data is.

In particular this opens up strategies where teams move the camera before taking a frame (to get a different view), or stop moving in order to remove motion blur.

See also https://github.com/sourcebots/robot-api/pull/35.