### PR TITLE
Make sb-vision an optional import

### DIFF
--- a/robotd/camera.py
+++ b/robotd/camera.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import time
+from devices_base import Board
+
+from sb_vision import Camera as VisionCamera, Vision, Token
+
+class Camera(Board):
+    """Camera"""
+    lookup_keys = {
+        'subsystem': 'video4linux',
+    }
+
+    DISTANCE_MODEL = 'c270'
+    IMAGE_SIZE = (1280, 720)
+
+    def __init__(self, node, camera=None):
+        super().__init__(node)
+        self.camera = camera
+
+    @classmethod
+    def name(cls, node):
+        # Get device name
+        return Path(node['DEVNAME']).stem
+
+    def start(self):
+        if not self.camera:
+            self.camera = VisionCamera(
+                int(self.node['MINOR']),
+                self.IMAGE_SIZE,
+                self.DISTANCE_MODEL,
+            )
+        self.vision = Vision(self.camera)
+
+        self._status = {
+            'snapshot_timestamp': None,
+            'markers': [],
+        }
+
+    def _update_status(self, markers):
+        self._status = {
+            'snapshot_timestamp': time.time(),
+            'markers': markers,
+        }
+
+    @staticmethod
+    def _serialise_marker(marker: Token):
+        d = marker.__dict__
+        d['homography_matrix'] = marker.homography_matrix.tolist()
+        d['cartesian'] = marker.cartesian.tolist()
+        return d
+
+    def status(self):
+        return self._status
+
+    def command(self, cmd):
+        """Run user-provided command."""
+        if cmd.get('see', False):
+            self._update_status(markers=[
+                self._serialise_marker(x)
+                for x in self.vision.snapshot()
+            ])
+            # rely on the status being sent back to the requesting connection
+            # by the ``BoardRunner``.

--- a/robotd/camera.py
+++ b/robotd/camera.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import time
-from devices_base import Board
+from .devices_base import Board
 
 from sb_vision import Camera as VisionCamera, Vision, Token
 

--- a/robotd/devices.py
+++ b/robotd/devices.py
@@ -1,14 +1,20 @@
 """Actual device classes."""
 
 import os
-from pathlib import Path
 import random
 import struct
 import subprocess
-import time
-
-from sb_vision import Camera as VisionCamera, Vision, Token
 import serial
+
+try:
+    import sb_vision
+    ENABLE_VISION = True
+except ImportError:
+    print("WARNING: sb_vision not installed, disabling vision support")
+    ENABLE_VISION = False
+
+if ENABLE_VISION:
+    from .camera import *
 
 from . import usb
 from .devices_base import Board, BoardMeta
@@ -212,65 +218,6 @@ class PowerBoard(Board):
         elif 'buzz' in cmd:
             self._buzz_piezo(cmd['buzz'])
 
-
-class Camera(Board):
-    """Camera"""
-
-    lookup_keys = {
-        'subsystem': 'video4linux',
-    }
-
-    DISTANCE_MODEL = 'c270'
-    IMAGE_SIZE = (1280, 720)
-
-    def __init__(self, node, camera=None):
-        super().__init__(node)
-        self.camera = camera
-
-    @classmethod
-    def name(cls, node):
-        # Get device name
-        return Path(node['DEVNAME']).stem
-
-    def start(self):
-        if not self.camera:
-            self.camera = VisionCamera(
-                int(self.node['MINOR']),
-                self.IMAGE_SIZE,
-                self.DISTANCE_MODEL,
-            )
-        self.vision = Vision(self.camera)
-
-        self._status = {
-            'snapshot_timestamp': None,
-            'markers': [],
-        }
-
-    def _update_status(self, markers):
-        self._status = {
-            'snapshot_timestamp': time.time(),
-            'markers': markers,
-        }
-
-    @staticmethod
-    def _serialise_marker(marker: Token):
-        d = marker.__dict__
-        d['homography_matrix'] = marker.homography_matrix.tolist()
-        d['cartesian'] = marker.cartesian.tolist()
-        return d
-
-    def status(self):
-        return self._status
-
-    def command(self, cmd):
-        """Run user-provided command."""
-        if cmd.get('see', False):
-            self._update_status(markers=[
-                self._serialise_marker(x)
-                for x in self.vision.snapshot()
-            ])
-            # rely on the status being sent back to the requesting connection
-            # by the ``BoardRunner``.
 
 
 class ServoAssembly(Board):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
         'robotd/native/libusb_build.py:ffibuilder',
     ],
     install_requires=[
-        'sb-vision',
         'pyudev',
         'pyserial',
         "cffi>=1.4.0",


### PR DESCRIPTION
sb-vision is a pain to install for some due to opencv versions.

To much improve ease of development, make the dependency optional.