### PR TITLE
Clean up install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,9 @@ setup(
         'robotd/native/libusb_build.py:ffibuilder',
     ],
     install_requires=[
-        'pyudev',
-        'pyserial',
         "cffi>=1.4.0",
+        'pyserial',
+        'pyudev',
         'setproctitle',
     ],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         'robotd/native/libusb_build.py:ffibuilder',
     ],
     install_requires=[
-        "cffi>=1.4.0",
+        'cffi>=1.4.0',
         'pyserial',
         'pyudev',
         'sb-vision',

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "cffi>=1.4.0",
         'pyserial',
         'pyudev',
+        'sb-vision',
         'setproctitle',
     ],
     entry_points={


### PR DESCRIPTION
Is there a reason that `sb-vision` was omitted from this list, or was it just a mistake?