### PR TITLE
reorder changelog to be reverse-chronological

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,12 +1,13 @@
-robotd (0) unstable; urgency=low
-
-  * (No changelog)
-
- -- Alistair Lynn <arplynn@gmail.com>  Wed, 22 Feb 2017 05:47:00 +0000
-
 robotd (2018.2.0) unstable; urgency=low
 
   * (No changelog)
 
  -- Andrew Barrett-Sprot <abarrettsprot@gmail.com>  Sun, 7 March 2017 22:47:00 +0000
+
+
+robotd (0) unstable; urgency=low
+
+  * (No changelog)
+
+ -- Alistair Lynn <arplynn@gmail.com>  Wed, 22 Feb 2017 05:47:00 +0000
 


### PR DESCRIPTION
Oops looks like the last change (which was merged) didn't update the version of the .deb file because they need to be reverse-chronological