### PR TITLE
Return analogue values as float rather than strings

### DIFF
--- a/robotd/devices.py
+++ b/robotd/devices.py
@@ -450,7 +450,7 @@ class ServoAssembly(Board):
         results = self._command('analogue-read')
         for result in results:
             name, value = result.split(' ')
-            self._analogue_values.update({name: value})
+            self._analogue_values.update({name: float(value)})
 
     def _read_ultrasound(self, trigger_pin, echo_pin):
         found_values = []


### PR DESCRIPTION
https://trello.com/c/pxVT9ioJ/49-analogue-pins-should-probably-return-floats

`robot-api` type signatures need updating before this can be merged.

Turns out the documentation already showed it returning a float, which is strange